### PR TITLE
docs: specify the class being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 *  Using the Cloudinary Facade
 */
 
+use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
+
 // access the admin api
 (https://cloudinary.com/documentation/admin_api)
 Cloudinary::admin();


### PR DESCRIPTION
Though it clearly says 'Facades', there is also a Cloudinary/Clodinary namespace and it can get confusing.