### PR TITLE
chore: update test matrix to test against 7.2+

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
+        # TODO: remove --ignore-platform-reqs when we have stable v2 release
         run: composer install --no-interaction --prefer-dist --optimize-autoloader --ignore-platform-reqs
 
       - name: Execute tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --ignore-platform-req
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader --ignore-platform-req
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --ignore-platform-reqs
 
       - name: Execute tests
         run: vendor/bin/pest


### PR DESCRIPTION
This adds PHP 7.2+ to the test matrix to make sure any changes support all versions back to what `composer.json` requires.