### PR TITLE
Properly handle Cloudinary public IDs and extensions for media and raw resources

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -32,7 +32,7 @@ class CloudinaryAdapter implements FilesystemAdapter
      */
     public $mediaExtensions = [
         'jpg', 'jpeg', 'png', 'gif', 'pdf', 'bmp', 'tiff', 'svg', 'ico', 'eps', 'psd', 'webp', 'jxr', 'wdp',
-        'mpeg', 'mp4', 'mkv', 'mov', 'flv', 'avi', '3gp', '3g2', 'wmv', 'webm', 'ogv', 'mxf',
+        'mpeg', 'mp4', 'mkv', 'mov', 'flv', 'avi', '3gp', '3g2', 'wmv', 'webm', 'ogv', 'mxf', 'avif',
     ];
 
     /**

--- a/tests/Unit/CloudinaryAdapterTest.php
+++ b/tests/Unit/CloudinaryAdapterTest.php
@@ -14,3 +14,16 @@ it('can get url given public id', function () {
     $result = Storage::disk('cloudinary')->url($file);
     expect($result)->toEqual($url);
 });
+
+it('removes extensions from media resources but not raw resources', function ($actual, $expected) {
+    $adapter = Storage::disk('cloudinary')->getAdapter();
+
+    expect($adapter->preparePublicId($actual))->toBe($expected);
+})->with([
+    ['file.jpg', 'file'],
+    ['file.png', 'file'],
+    ['file.gif', 'file'],
+    ['file.xlsx', 'file.xlsx'],
+    ['file.zip', 'file.zip'],
+    ['file.csv', 'file.csv'],
+]);


### PR DESCRIPTION
Historically, Cloudinary is known to not play nice with extensions in public ids for media resources. This is so that we can easily transform the resources to various other types for delivering with possible transformations.

When resources are being uploaded, the package currenty removes the extension from the public ID passed to Cloudinary.
This is great, as Cloudinary recommends to not include file extensions in public IDs for media resources, however, they SHOULD be included for raw resources.

<img width="1347" alt="Screenshot 2024-08-14 at 03 12 28" src="https://github.com/user-attachments/assets/53d47af6-6ae6-4f7f-a550-079657c32e15">

https://cloudinary.com/documentation/image_upload_api_reference

This PR solves two problems:
- Removes extensions from media resources `public_id` but not raw resources.
- Allows other methods on the `Storage` facade like `exists`, `delete`, `rename`, etc to still work when the `public_id` is supplied with its extension.
```php
// Assuming the default storage disk is `cloudinary`.

Storage::delete('avatar-1.jpg'); // Works

Storage::delete('avatar-1'); // Still works

// This makes it possible to do this;
$path = $request->file('avatar')->store();

Storage::delete($path);
// Which wasn't possible before this PR.
```
This way, people can switch storage disks and not make any changes to their code.
- I believe this also fixes #124